### PR TITLE
Developer sees that the last SHA used in a plan is applied when merging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,6 @@ name: Docker image
 
 on: [push]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   build:
     name: Build image
@@ -20,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Login to GitHub Repository
         uses: docker/login-action@v3
@@ -33,6 +29,6 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}/cal-bc:${{ github.ref == 'refs/heads/main' && 'latest' || 'development' }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cal-bc:${{ github.ref == 'refs/heads/main' && 'latest' || 'development' }}
+          tags: ghcr.io/${{ github.repository }}/cal-bc:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cal-bc:${{ github.sha }}
           cache-to: type=inline

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -54,3 +54,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: iac/
+          variables: |
+            image_tag = "${{ github.sha }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -63,3 +63,5 @@ jobs:
         with:
           add_github_comment: changes-only
           path: iac/
+          variables: |
+            image_tag = "${{ github.sha }}"

--- a/iac/service.tf
+++ b/iac/service.tf
@@ -24,7 +24,8 @@ resource "google_cloud_run_v2_service" "cal-bc-staging" {
     }
 
     containers {
-      image = "us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/cal-bc/cal-bc:development"
+      image = "us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/cal-bc/cal-bc:${var.image_tag}"
+
       ports {
         container_port = 8000
       }

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -20,3 +20,9 @@ resource "random_password" "cal-bc-staging-database" {
 locals {
   domain = "cal-bc-staging.dds.dot.ca.gov"
 }
+
+variable "image_tag" {
+  type        = string
+  description = "The tag used for image deployment"
+  default     = "latest"
+}


### PR DESCRIPTION
# Summary

This PR sets up terraform to deploy the most recently planned SHA when merging a PR.

Relates to #37 

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Configuration

## Post-merge actions
Monitor `terraform apply`