### PR TITLE
Deploy Cal-B/C to Cloud Run using the latest Github SHA

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,10 +2,6 @@ name: Docker image
 
 on: [push]
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
-
 jobs:
   build:
     name: Build image
@@ -33,6 +29,8 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           push: true
-          tags: ghcr.io/${{ github.repository }}/cal-bc:${{ github.ref == 'refs/heads/main' && 'latest' || 'development' }}
-          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cal-bc:${{ github.ref == 'refs/heads/main' && 'latest' || 'development' }}
+          tags: |
+            ghcr.io/${{ github.repository }}/cal-bc:latest
+            ghcr.io/${{ github.repository }}/cal-bc:${{ github.sha }}
+          cache-from: type=registry,ref=ghcr.io/${{ github.repository }}/cal-bc:latest
           cache-to: type=inline

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -54,3 +54,5 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           path: iac/
+          variables: |
+            image_tag = "${{ github.sha }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -63,3 +63,5 @@ jobs:
         with:
           add_github_comment: changes-only
           path: iac/
+          variables: |
+            image_tag = "${{ github.sha }}"

--- a/iac/service.tf
+++ b/iac/service.tf
@@ -24,7 +24,8 @@ resource "google_cloud_run_v2_service" "cal-bc-staging" {
     }
 
     containers {
-      image = "us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/cal-bc/cal-bc:development"
+      image = "us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/cal-bc/cal-bc:${var.image_tag}"
+
       ports {
         container_port = 8000
       }

--- a/iac/terraform.tfvars
+++ b/iac/terraform.tfvars
@@ -1,0 +1,1 @@
+image_tag = "latest"

--- a/iac/variables.tf
+++ b/iac/variables.tf
@@ -7,6 +7,10 @@ data "terraform_remote_state" "iam" {
   }
 }
 
+variable "image_tag" {
+  type = string
+}
+
 resource "random_password" "cal-bc-staging-secret-key" {
   special = false
   length  = 50


### PR DESCRIPTION
# Summary

This PR updates the Terraform and Docker deployment flow to tag and deploy the current Github SHA, paving the way for production/staging deployment and rollback.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Configuration

## Post-merge actions

- Monitor Docker build
- Monitor Terraform apply
