### PR TITLE
Use the base SHA when calculating the SHA for a pull request

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -48,6 +48,18 @@ jobs:
       - name: Setup GCloud utilities
         uses: google-github-actions/setup-gcloud@v2
 
+      - name: Terraform Apply Cloud Run
+        uses: dflook/terraform-apply@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path: iac/
+          auto_approve: true
+          variables: |
+            image_tag = "${{ github.ref == 'refs/heads/main' && github.sha || github.event.pull_request.head.sha }}"
+          target: |
+            google_cloud_run_v2_service.cal-bc-staging
+
       - name: Terraform Apply
         uses: dflook/terraform-apply@v2
         env:
@@ -55,4 +67,4 @@ jobs:
         with:
           path: iac/
           variables: |
-            image_tag = "${{ github.sha }}"
+            image_tag = "${{ github.ref == 'refs/heads/main' && github.sha || github.event.pull_request.head.sha }}"

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -64,4 +64,4 @@ jobs:
           add_github_comment: changes-only
           path: iac/
           variables: |
-            image_tag = "${{ github.sha }}"
+            image_tag = "${{ github.ref == 'refs/heads/main' && github.sha || github.event.pull_request.head.sha }}"


### PR DESCRIPTION
# Summary

This PR uses the pull request base SHA to calculate the planned Docker tag for Terraform.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Configuration

## Post-merge actions

Monitor `terraform apply`