### PR TITLE
Add First Name to Welcome paragraph on Projects and Models pages

### DIFF
--- a/src/cal_bc/models/templates/models/index.html
+++ b/src/cal_bc/models/templates/models/index.html
@@ -8,7 +8,7 @@
 
     <header class="mx-auto max-w-7xl py-6 px-6 lg:px-8">
         <div class="space-y-2">
-            <p class="mt-4 uppercase text-base font-light text-pretty text-dds-teal-700">Welcome,</p>
+            {% if user.get_short_name != "" %}<p class="mt-4 uppercase text-base font-light text-pretty text-dds-teal-700">Welcome, {{user.get_short_name}}</p>{% endif %}
             <h2 class="mt-4 text-4xl font-bold tracking-tight text-dds-teal-950">Start a new benefit-cost analysis</h2>
             <p class="text-base font-light text-pretty text-gray-700">
                 Choose the Cal B/C model that matches your project type. Each model is tailored to a specific mode and uses California state-average defaults where applicable.

--- a/src/cal_bc/projects/templates/_footer.html
+++ b/src/cal_bc/projects/templates/_footer.html
@@ -1,5 +1,5 @@
 <footer class="bg-gray-200">
     <div class="mx-auto max-w-7xl px-6 py-2 md:flex md:items-center md:justify-between lg:px-8">
-        <p class="text-center font-semibold text-sm/6 text-gray-600 md:order-1 md:mt-0">California Department of Transportation <span class="px-1">•</span> Office of Transportation Economics <span class="px-1">•</span> Transportation Planning Division</p>
+        <p class="text-center font-semibold text-sm/6 text-gray-600 md:order-1 md:mt-0">© 2026 <span class="px-1">•</span> California Department of Transportation <span class="px-1">•</span> Office of Transportation Economics <span class="px-1">•</span> Transportation Planning Division</p>
     </div>
 </footer>

--- a/src/cal_bc/projects/templates/projects/index.html
+++ b/src/cal_bc/projects/templates/projects/index.html
@@ -1,6 +1,5 @@
 {% extends "base.html" %}
-{% load static i18n %}
-{% load svg %}
+{% load static i18n svg %}
 {% block main %}
 {% include "_statewide_header.html" %}
 
@@ -9,7 +8,7 @@
 
     <header class="relative">
         <div class="mx-auto max-w-7xl py-6 px-6 lg:px-8">
-            <p class="mt-4 uppercase text-base font-light text-pretty text-dds-teal-700">Welcome,</p>
+            {% if user.get_short_name != "" %}<p class="mt-4 uppercase text-base font-light text-pretty text-dds-teal-700">Welcome, {{user.get_short_name}}</p>{% endif %}
             <div class="sm:flex sm:items-center">
                 <div class="sm:flex-auto space-y-2">
                     <h2 class="mt-4 text-4xl font-bold tracking-tight text-dds-teal-950">My Cal B/C Analyses</h2>

--- a/tests/cal_bc/views/test_model_views.py
+++ b/tests/cal_bc/views/test_model_views.py
@@ -10,7 +10,7 @@ from unbrowsed import parse_html, query_by_text
 class TestModelViews:
     @pytest.fixture
     def user(self, django_user_model) -> User:
-        return django_user_model.objects.create_user(username="caltrans")
+        return django_user_model.objects.create_user(username="caltrans", first_name="John", last_name="Luis")
 
     @pytest.fixture
     def model(self) -> Model:
@@ -34,4 +34,5 @@ class TestModelViews:
         response = client.get(reverse_lazy("models"))
         assert response.status_code == 200
         dom = parse_html(response.content)
+        assert query_by_text(dom, "Welcome, John")
         assert query_by_text(dom, "Testing v1")

--- a/tests/cal_bc/views/test_project_views.py
+++ b/tests/cal_bc/views/test_project_views.py
@@ -12,7 +12,7 @@ from unbrowsed import parse_html, query_by_text
 class TestProjectViews:
     @pytest.fixture
     def user(self, django_user_model) -> User:
-        return django_user_model.objects.create_user(username="caltrans")
+        return django_user_model.objects.create_user(username="caltrans", first_name="Maria", last_name="Mary")
 
     @pytest.fixture
     def model(self) -> Model:
@@ -66,6 +66,7 @@ class TestProjectViews:
         response = client.get(reverse_lazy("projects"))
         assert response.status_code == 200
         dom = parse_html(response.content)
+        assert query_by_text(dom, "Welcome, Maria")
         assert query_by_text(dom, "My Cal B/C Analyses")
         assert query_by_text(dom, "New analysis")
         assert query_by_text(dom, "0 analyses")
@@ -77,6 +78,7 @@ class TestProjectViews:
         response = client.get(reverse_lazy("projects"))
         assert response.status_code == 200
         dom = parse_html(response.content)
+        assert query_by_text(dom, "Welcome, Maria")
         assert query_by_text(dom, "My Cal B/C Analyses")
         assert query_by_text(dom, "New analysis")
         assert query_by_text(dom, "1 analyses")


### PR DESCRIPTION
# Summary

This PR adds the user's `First Name` to the Welcome paragraph on Projects and Models pages.

I also added the year `© 2026` to the Footer that was included on the Design. It is such a tiny change. that does not worth a new issue and PR.

Resolves https://github.com/cal-itp/cal-bc/issues/153

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Configuration

## Acceptance notes

- [ ] When the user has a First Name, it shows on the [Projects page](https://cal-bc-staging.dds.dot.ca.gov/projects/):
<img width="824" height="281" alt="image" src="https://github.com/user-attachments/assets/b582fbce-4c28-463c-9d5a-3820a15d0e4d" />
<br>
<br>

- [ ] When the user has a First Name, it shows on the [Models page](https://cal-bc-staging.dds.dot.ca.gov/models/):
<img width="1219" height="290" alt="image" src="https://github.com/user-attachments/assets/67f8f749-ccb3-41c5-b454-03b51ce735c2" />
