### PR TITLE
Don't show Models without Versions

### DIFF
--- a/src/cal_bc/models/models/model.py
+++ b/src/cal_bc/models/models/model.py
@@ -11,8 +11,8 @@ class Model(models.Model):
         return self.name
 
     def latest_version(self):
-        return list(self.version_set.all())[-1]
-
+        versions = list(self.version_set.all())
+        return versions[-1] if len(versions) > 0 else None
 
 class Version(models.Model):
     class Meta:

--- a/src/cal_bc/models/templates/models/index.html
+++ b/src/cal_bc/models/templates/models/index.html
@@ -16,11 +16,12 @@
         </div>
     </header>
 
-    {% for model in object_list %}
+    {% for model in model_list %}
     <div class="mx-auto max-w-7xl py-6 px-6 lg:px-8">
         <ul role="list" class="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
+            {% with model.latest_version as version %}
+            {% if version %}
             <li class="divide-y divide-gray-200 border border-gray-200 rounded-lg bg-white p-6 hover:border-dds-teal-600">
-                {% with model.latest_version as version %}
                 <form method="post" action="{% url 'model_project_new' model.id version.id %}">
                     {% csrf_token %}
                     <button type="submit">
@@ -40,8 +41,9 @@
                         </div>
                     </button>
                 </form>
-                {% endwith %}
             </li>
+            {% endif %}
+            {% endwith %}
         </ul>
     </div>
     {% endfor %}

--- a/tests/cal_bc/models/test_model.py
+++ b/tests/cal_bc/models/test_model.py
@@ -4,13 +4,13 @@ from cal_bc.models.models.model import Model, Version, Section, Subsection, Grou
 
 @pytest.mark.django_db
 class TestModels:
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def model(self) -> Model:
         return Model.objects.create(
             name="Cal-B/C Sketch",
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def version(self, model: Model) -> Version:
         return Version.objects.create(
             model=model,
@@ -18,7 +18,7 @@ class TestModels:
             url="https://example.com",
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def earlier_version(self, model: Model) -> Version:
         return Version.objects.create(
             model=model,
@@ -26,7 +26,7 @@ class TestModels:
             url="https://example.com",
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def section(self, version: Version) -> Section:
         return Section.objects.create(
             version=version,
@@ -34,7 +34,7 @@ class TestModels:
             name="Project Information"
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def subsection(self, section: Section) -> Subsection:
         return Subsection.objects.create(
             section=section,
@@ -42,7 +42,7 @@ class TestModels:
             name="Project Data"
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def group(self, subsection: Subsection) -> Group:
         return Group.objects.create(
             subsection=subsection,
@@ -50,14 +50,14 @@ class TestModels:
             position=1
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def row(self, group: Group) -> Row:
         return Row.objects.create(
             group=group,
             position=1
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def field(self, row: Row) -> Field:
         return Field.objects.create(
             row=row,
@@ -65,7 +65,7 @@ class TestModels:
             position=1
         )
 
-    @pytest.fixture(autouse=True)
+    @pytest.fixture()
     def value(self, field: Field) -> Value:
         return Value.objects.create(
             field=field,
@@ -79,6 +79,9 @@ class TestModels:
 
     def test_model_latest_version(self, model: Model, version: Version):
         assert model.latest_version() == version
+
+    def test_model_latest_version_no_versions(self, model: Model):
+        assert model.latest_version() is None
 
     def test_version_string_representation(self, version: Version):
         assert str(version) == "Cal-B/C Sketch v8.1"


### PR DESCRIPTION
# Summary

This PR fixes a bug where visiting the `/models` page resulted in a 500 error when there were any Models in the DB with no associated Version. Models should be able to not have Versions without this page breaking. For instance, admins will be in various stages of setting up Models and might not yet have all the information for a Version. Instead of making a Version required for creating a Model, the solution in this PR is just to gracefully fail on the frontend when there is not an associated Version.

Resolves [https://github.com/cal-itp/cal-bc/issues/<issue number>](https://github.com/cal-itp/cal-bc/issues/148)

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Configuration

## Acceptance notes

1. Create a Model in the admin section, but don't add a Version to it
2. Visit the `/models` page and see that it loads as expected, but that it does not show the Model you created that does not yet have a Version. Only Models that have Versions will show on the page.
