### PR TITLE
Developer can run migrations via the command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,21 @@ $ uv run ruff check --fix
 ```
 
 
+### Managing Django in Cloud Run
+
+To run `manage.py` commands on the deployed Cloud Run instance, use the [cal-bc-staging-manage](https://console.cloud.google/run/jobs/details/us-west2/cal-bc-staging-manage) Cloud Run Job.
+
+For example, if you want to migrate the `models` app back to a specific migration, you would locally run:
+```bash
+$ uv run manage.py migrate models 0013_subsection_description
+```
+
+The Cloud Run Jobs equivalent using `cal-bc-staging-manage` is:
+```bash
+$ gcloud run jobs execute cal-bc-staging-manage --args migrate,models,0013_subsection_description --wait
+```
+
+
 ### Administering the site locally
 
 In order to access the admin site at [http://localhost:8000/admin](http://localhost:8000/admin), you need to create a superuser for your DOT login:

--- a/iac/jobs.tf
+++ b/iac/jobs.tf
@@ -1,0 +1,51 @@
+resource "google_cloud_run_v2_job" "cal-bc-staging-manage" {
+  name                = "cal-bc-staging-manage"
+  location            = "us-west2"
+  deletion_protection = false
+
+  template {
+    template {
+      service_account = data.terraform_remote_state.iam.outputs.google_service_account_cal-bc-service-account_email
+      max_retries = 0
+
+      volumes {
+        name = "cloudsql"
+
+        cloud_sql_instance {
+          instances = [google_sql_database_instance.cal-bc-staging.connection_name]
+        }
+      }
+
+      containers {
+        image   = "us-west2-docker.pkg.dev/cal-itp-data-infra-staging/ghcr/cal-itp/cal-bc/cal-bc:${var.image_tag}"
+        command = ["uv", "run", "--no-sync", "manage.py"]
+        args    = ["help"]
+
+        volume_mounts {
+          name       = "cloudsql"
+          mount_path = "/cloudsql"
+        }
+
+        env {
+          name = "SECRET_KEY"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.cal-bc-staging-secret-key.secret_id
+              version = "latest"
+            }
+          }
+        }
+
+        env {
+          name = "DATABASE_URL"
+          value_source {
+            secret_key_ref {
+              secret  = google_secret_manager_secret.cal-bc-staging-database-url.secret_id
+              version = "latest"
+            }
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
# Summary

This PR adds a Cloud Run Job to run Django's `manage.py`.

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Configuration