### PR TITLE
Developer sees that the service and job updates are both auto-approved

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -59,6 +59,7 @@ jobs:
             image_tag = "${{ github.ref == 'refs/heads/main' && github.sha || github.event.pull_request.head.sha }}"
           target: |
             google_cloud_run_v2_service.cal-bc-staging
+            google_cloud_run_v2_job.cal-bc-staging-manage
 
       - name: Terraform Apply
         uses: dflook/terraform-apply@v2


### PR DESCRIPTION
# Summary

This PR adds the Cloud Run Job for running `manage.py` tasks to the auto_approve `terraform apply` workflow step. Currently `terraform apply`s fail due to the job's image SHA not being in the plan, since the SHA differs between the PR branch and main.

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Configuration

## Acceptance notes

`terraform apply` is green