### PR TITLE
Fix alignment on table cell fields with unit

### DIFF
--- a/src/cal_bc/projects/templates/projects/_form.html
+++ b/src/cal_bc/projects/templates/projects/_form.html
@@ -21,8 +21,8 @@
                 {% render_field field|append_attr:"hx-on:input changed once -> this.setAttribute('hx-morph-skip','true')" hx-get=row_url hx-params="none" hx-swap="innerMorph" hx-target="#guide" hx-trigger="focus" class="col-start-1 row-start-1 w-full appearance-none pl-5 pr-12 py-3 rounded-xs bg-white text-lg text-gray-900 outline-1 -outline-offset-1 outline-gray-600 placeholder:text-gray-400 focus:outline-2 focus:-outline-offset-2 focus:outline-dds-teal-600" %}
                 {% svg "projects/chevron_down" class="pointer-events-none col-start-1 row-start-1 mr-4 size-6 self-center justify-self-end fill-dds-teal-600" %}
             {% elif form.initial.field.unit or form.instance.field.unit %}
-                <div class="w-full flex items-baseline rounded-xs bg-white py-3 text-lg text-gray-900 outline-1 -outline-offset-1 outline-gray-600 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-dds-teal-600">
-                    {% render_field field|append_attr:"hx-on:input changed once -> this.setAttribute('hx-morph-skip','true')" hx-get=row_url hx-params="none" hx-swap="innerMorph" hx-target="#guide" hx-trigger="focus" class="flex-grow block pr-3 text-center outline-none placeholder:text-gray-400 " %}
+                <div class="flex items-baseline rounded-xs bg-white py-3 text-lg text-gray-900 outline-1 -outline-offset-1 outline-gray-600 focus-within:outline-2 focus-within:-outline-offset-2 focus-within:outline-dds-teal-600">
+                    {% render_field field|append_attr:"hx-on:input changed once -> this.setAttribute('hx-morph-skip','true')" hx-get=row_url hx-params="none" hx-swap="innerMorph" hx-target="#guide" hx-trigger="focus" class="w-full flex-grow block pr-3 text-center outline-none placeholder:text-gray-400 " %}
                     <div class="shrink-0 pr-5 text-base text-gray-600 select-none sm:text-sm/6" id="{% firstof form.initial.field.name form.instance.field.name|slugify %}-unit">{% firstof form.initial.field.unit form.instance.field.unit %}</div>
                 </div>
             {% else %}


### PR DESCRIPTION
# Summary

This PR fixes an alignment issue with field inputs that are in a table. Here's an example of the defect

<img width="1013" height="1144" alt="Screenshot 2026-08-12 at 10 50 11 AM" src="https://github.com/user-attachments/assets/30b09c27-e85c-4873-b954-74adcf2324e0" />

Relates to https://github.com/cal-itp/cal-bc/issues/108

## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Configuration
