### PR TITLE
Allow adding money units to fields

### DIFF
--- a/src/cal_bc/projects/templates/components/form_field.html
+++ b/src/cal_bc/projects/templates/components/form_field.html
@@ -20,7 +20,9 @@
     {% render_field field|append_attr:"hx-on:input changed once -> this.setAttribute('hx-morph-skip','true')" hx-get=row_url hx-params="none" hx-swap="innerMorph" hx-target="#guide" hx-trigger="focus" class=input_styles|get_item:variant %}
 
     {% if variant == 'with_unit' %}
-        <div class="shrink-0 pr-5 text-gray-600 select-none" id="{% firstof form.initial.field.name form.instance.field.name|slugify %}-unit">{% firstof form.initial.field.unit form.instance.field.unit %}</div>
+        <div class="{% if form.initial.field.unit == '$' or form.instance.field.unit == '$' %}order-first pl-5 {% else %}pr-5 {% endif %}shrink-0 text-gray-600 select-none" id="{% firstof form.initial.field.name form.instance.field.name|slugify %}-unit">
+            {% firstof form.initial.field.unit form.instance.field.unit %}
+        </div>
     {% endif %}
 
     {% if variant == 'select' %}

--- a/tests/cal_bc/system/test_project_system.py
+++ b/tests/cal_bc/system/test_project_system.py
@@ -119,7 +119,7 @@ class TestProjectSystem:
 
     @pytest.fixture(autouse=True)
     def cars_per_hour(self, group_2_row_1: Row) -> Field:
-        return group_2_row_1.field_set.create(name="Cars per hour", cell="ADT0", unit="each")
+        return group_2_row_1.field_set.create(name="Annual Capital Expenditure", cell="ADT0", unit="$")
 
     @pytest.fixture(autouse=True)
     def district_4(self, district_field: Field) -> Value:
@@ -168,8 +168,8 @@ class TestProjectSystem:
 
         first_page.get_by_role("button", name="Save draft").click()
         expect(first_page.locator("body")).to_contain_text("This field is required")
-        first_page.get_by_label("Cars per hour").fill("333")
-        expect(first_page.locator("#cars-per-hour-unit")).to_contain_text("each")
+        first_page.get_by_label("Annual Capital Expenditure").fill("333")
+        expect(first_page.locator("#annual-capital-expenditure-unit")).to_contain_text("$")
         first_page.get_by_role("button", name="Back to Subsection 1A").click()
         first_page.get_by_role("button", name="1A - Project Data").click()
         first_page.get_by_role("menuitem", name="1B. Traffic Data").click()


### PR DESCRIPTION
# Summary

Following the designs, this PR shows the USD sign on a field if provided as the unit for the field. Keeping it super simple for now and simply matching on if the unit is '$'. 

Resolves https://github.com/cal-itp/cal-bc/issues/111

<img width="1166" height="983" alt="Screenshot 2026-08-13 at 10 32 30 AM" src="https://github.com/user-attachments/assets/3c352119-1576-4051-aa32-b4635a2af9b3" />

## Type of change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Configuration

## Acceptance notes

1. In the admin area, add '$' as the unit to any field
2. See that it renders correctly in the form
