### PR TITLE
Fix issue with subsection nav menu width

### DIFF
--- a/src/cal_bc/projects/templates/projects/_header_nav.html
+++ b/src/cal_bc/projects/templates/projects/_header_nav.html
@@ -9,7 +9,7 @@
         {% svg "projects/chevron_down" class="pointer-events-none col-start-1 row-start-1 size-6 self-center justify-self-end fill-dds-teal-500" %}
     </button>
 
-    <el-menu anchor="bottom end" popover class="w-(--button-width) origin-top-right rounded-xs bg-white text-lg shadow-lg outline-1 outline-black/5 transition transition-discrete [--anchor-gap:--spacing(0.25)] data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in">
+    <el-menu anchor="bottom end" popover class="w-[450px] origin-top-right rounded-xs bg-white text-lg shadow-lg outline-1 outline-black/5 transition transition-discrete [--anchor-gap:--spacing(0.25)] data-closed:scale-95 data-closed:transform data-closed:opacity-0 data-enter:duration-100 data-enter:ease-out data-leave:duration-75 data-leave:ease-in">
         {% for section_option in subsection.section.version.section_set.all %}
             <div class="font-semibold block px-4 py-2 text-gray-700 underline focus:bg-gray-100 focus:text-gray-900 focus:outline-hidden">Section {{section_option.code}}: {{ section_option.name }}</div>
             {% for subsection_option in section_option.subsection_set.all %}


### PR DESCRIPTION
# Summary

There is an issue with using the Tailwind Elements select menu helper `--button-width` where it doesn't always get applied in time. This could likely also be helped by setting up the app with a CDN, but for now the easiest thing to do was to specify the needed width manually so no JS is required. 

<img width="1307" height="821" alt="Screenshot 2026-08-14 at 10 56 44 AM" src="https://github.com/user-attachments/assets/f9a1d0e9-6aab-41d3-899b-d11136a0c022" />


## Type of change

- [ ] New feature
- [x] Bug fix
- [ ] Documentation
- [ ] Configuration