### PR TITLE
Admin can Add a Group from the Groups page

### DIFF
--- a/src/cal_bc/models/admin.py
+++ b/src/cal_bc/models/admin.py
@@ -38,7 +38,7 @@ class FieldColumnInline(nested_admin.NestedTabularInline):
             return 1
 
     def formfield_for_foreignkey(self, db_field, request, **kwargs):
-        if db_field.name == "column":
+        if db_field.name == "column" and request.resolver_match.kwargs:
             kwargs["queryset"] = Column.objects.filter(
                 column_group__group=request.resolver_match.kwargs["object_id"]
             )

--- a/src/cal_bc/models/admin.py
+++ b/src/cal_bc/models/admin.py
@@ -107,6 +107,8 @@ class GroupAdmin(nested_admin.NestedModelAdmin):
     ordering = ["name"]
     search_fields = ["name", "subsection__code", "subsection__name", "subsection__code", "subsection__section__name", "subsection__section__version__name", "subsection__section__version__model__name"]
     search_help_text = "Search by Name, Model, Version, Section, and Subsection"
+    fields = ["model_name", "version_name", "section", "subsection", "name", "description"]
+    readonly_fields = ["model_name", "version_name", "section"]
 
     @admin.display(description="Model", ordering="subsection__section__version__model__name")
     def model_name(self, obj):

--- a/tests/cal_bc/system/test_model_system.py
+++ b/tests/cal_bc/system/test_model_system.py
@@ -102,7 +102,6 @@ class TestModelSystem:
         first_page.get_by_role(
             "link", name="General Information", exact=True
         ).click()
-        first_page.get_by_label("Description").fill("All fields are required.")
         first_page.locator(":text('Row: #1') + fieldset").get_by_label("Guide").locator(
             "~ [contenteditable]"
         ).fill("Complete this section")
@@ -123,13 +122,10 @@ class TestModelSystem:
         first_page.get_by_role("link", name="Add another Field", exact=True).click()
         first_page.locator(":text('Field: #2') + fieldset").get_by_label("Name").nth(
             0
-        ).fill("New trips from Parallel Hwy")
+        ).fill("Project Name")
         first_page.locator(":text('Field: #2') + fieldset").get_by_label("Cell").nth(
             0
-        ).fill("'1) Project Information'::Table 1::Q31")
-        first_page.locator(":text('Field: #2') + fieldset").get_by_label("Unit").nth(
-            0
-        ).fill("%")
+        ).fill("ProjName")
         first_page.get_by_role("link", name="Add another Field Range").nth(1).click()
         expect(first_page.locator(":text('Field range') ~ table tbody tr").nth(0).locator("td").nth(
             1
@@ -143,6 +139,23 @@ class TestModelSystem:
         first_page.get_by_role("button", name="Save", exact=True).click()
         first_page.wait_for_selector(
             "text=The group “General Information” was changed successfully"
+        )
+        first_page.get_by_role("link", name="Add group").click()
+        first_page.get_by_label("subsection").select_option("A - Project Data")
+        first_page.get_by_label("Name").nth(0).fill("Project Data")
+        first_page.get_by_label("Description").fill("Configure project analysis settings.")
+        first_page.locator(":text('Field: #1') + fieldset").get_by_label("Name").nth(
+            0
+        ).fill("Length of Construction Period")
+        first_page.locator(":text('Field: #1') + fieldset").get_by_label("Cell").nth(
+            0
+        ).fill("1) Project Information!F14")
+        first_page.locator(":text('Field: #1') + fieldset").get_by_label("Unit").nth(
+            0
+        ).fill("years")
+        first_page.get_by_role("button", name="Save", exact=True).click()
+        first_page.wait_for_selector(
+            "text=The group “Project Data” was added successfully"
         )
 
         first_page.close()


### PR DESCRIPTION
# Summary

This PR fixes the bug #233.
Admin can add a group from the Groups page.

Also added `Model`, `Version`, and `Section` fields (read only) to the Group page.

<img width="1182" height="540" alt="image" src="https://github.com/user-attachments/assets/a5201f2a-bf5d-48eb-a04b-70d26b8db64b" />

## Type of change

- [ ] New feature
- [x Bug fix
- [ ] Documentation
- [ ] Configuration

## Acceptance notes

1. Log in on Admin area
2. Click on Groups
3. Click on ADD GROUP +
4. See the Add group page

<img width="1186" height="581" alt="image" src="https://github.com/user-attachments/assets/0ab07b8a-f025-4913-917b-2143b30f7dd2" />


